### PR TITLE
[OPENNEBULA] do not check client body size

### DIFF
--- a/files/config/opennebula-sunstone
+++ b/files/config/opennebula-sunstone
@@ -2,6 +2,8 @@
 
     root /usr/lib/one/sunstone/public/;
 
+    client_max_body_size 0;
+
     try_files $uri/index.html $uri.html $uri @sunstone;
 
     location ~* \.(ico|css|js|gif|jpe?g|png)(\?[0-9]+)?$ {


### PR DESCRIPTION
set the directive to 0, so the check is disabled
(according to http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)